### PR TITLE
feat(docs): Write new DocBox documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Node rules:
+## Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
+.grunt
+
+## Dependency directory
+## Commenting this out is preferred by some people, see
+## https://docs.npmjs.com/misc/faq#should-i-check-my-node_modules-folder-into-git
+node_modules
+
+# Book build output
+_book
+
+# eBook build output
+*.epub
+*.mobi
+*.pdf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 There are several ways you can help in the development of DocBox!
 
 * [Send a pull request](#send-a-pull-request)
-* [Submit a bug or feature request](https://ortussolutions.atlassian.net/projects/DOCBOX)
+* Submit a bug or feature request to our [Jira issue tracker](https://ortussolutions.atlassian.net/projects/DOCBOX)
 * [Write a test](#testing-docbox)
 
 ## Send a Pull Request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+There are several ways you can help in the development of DocBox!
+
+* [Send a pull request](#send-a-pull-request)
+* [Submit a bug or feature request](https://ortussolutions.atlassian.net/projects/DOCBOX)
+* [Write a test](#testing-docbox)
+
+## Send a Pull Request
+
+* Fork [DocBox](https://github.com/Ortus-Solutions/DocBox) or the [DocBox documentation repo](https://github.com/ortus-docs/docbox-docs)
+* Clone the repository fork to your machine - `git clone git@github.com:ME/DocBox.git`
+* Create a `feature/` or `patch/` branch: `git checkout -b patch/syntax-error-in-html-output`
+* Make your changes, commit as normal, and use `git push` to sync your commits to Github.
+* Please target all PRs at the `development` branch.
+
+## Testing DocBox
+
+DocBox has a suite of Testbox specs validating that it works as expected. New features and bug fix PRs should (ideally) contain accompanying tests. Here's how to do that via CommandBox:
+
+1. After cloning the repo, run `box install` to install development dependencies
+2. Run `box start` to boot a test server
+3. Run `box testbox run` to run the suite of DocBox tests.
+4. Edit test specs in `tests/specs` as necessary, and run `box testbox run` again to validate tests pass.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ DocBox supports several output formats:
 
 ## Versioning <a id="versioning"></a>
 
-The ColdBox Security Module is maintained under the [Semantic Versioning](http://semver.org/) guidelines as much as possible.  Releases will be numbered with the following format:
+DocBox is maintained under the [Semantic Versioning](http://semver.org/) guidelines as much as possible.  Releases will be numbered with the following format:
 
 ```text
 <major>.<minor>.<patch>
@@ -37,7 +37,7 @@ Apache 2 License: [http://www.apache.org/licenses/LICENSE-2.0](https://www.apach
 
 ![Ortus Solutions, Corp](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LA-UVvG0NM7NpDzssBL%2F-LA-Uaei0WzTH7Su5CR7%2F-LA-UqN1BRXynZ7RUVO7%2Fortussolutions_button.png?generation=1523647999385555&alt=media)
 
-The ColdBox ORM Module is a professional open source software backed by [Ortus Solutions, Corp](http://www.ortussolutions.com/services) offering services like:
+DocBox is professional open source software backed by [Ortus Solutions, Corp](http://www.ortussolutions.com/services) offering services like:
 
 * Custom Development
 * Professional Support & Mentoring

--- a/README.md
+++ b/README.md
@@ -2,13 +2,10 @@
 
 DocBox is a JavaDoc-style documentation generator for your CFML codebase. DocBox reads component metadata and structured comments and outputs documentation in an HTML, JSON, or UML (diagram) format. DocBox is a fork of Mark Mandel's original ColdDoc project.
 
-## Supported Formats
+## SYSTEM REQUIREMENTS
 
-DocBox supports several output formats:
-
-* [HTML](output-formats/html.md)
-* [JSON](output-formats/json.md)
-* [UML](output-formats/uml.md)
+- Lucee 5+
+- ColdFusion 2016+
 
 ## Versioning <a id="versioning"></a>
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# Introduction
+
+DocBox is a JavaDoc-style documentation generator for your CFML codebase. DocBox reads component metadata and structured comments and outputs documentation in an HTML, JSON, or UML (diagram) format. DocBox is a fork of Mark Mandel's original ColdDoc project.
+
+## Supported Formats
+
+DocBox supports several output formats:
+
+* [HTML](output-formats/html.md)
+* [JSON](output-formats/json.md)
+* [UML](output-formats/uml.md)
+
+## Versioning <a id="versioning"></a>
+
+The ColdBox Security Module is maintained under the [Semantic Versioning](http://semver.org/) guidelines as much as possible.  Releases will be numbered with the following format:
+
+```text
+<major>.<minor>.<patch>
+```
+
+And constructed with the following guidelines:
+
+* Breaking backward compatibility bumps the major \(and resets the minor and patch\)
+* New additions without breaking backward compatibility bumps the minor \(and resets the patch\)
+* Bug fixes and misc changes bumps the patch
+
+## License <a id="license"></a>
+
+Apache 2 License: [http://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)​
+
+## Important Links <a id="important-links"></a>
+
+* Code: [https://github.com/coldbox-modules/cbsecurity](https://github.com/coldbox-modules/cbsecurity)​
+* Issues: [https://github.com/coldbox-modules/cbsecurity/issues](https://github.com/coldbox-modules/cbsecurity/issues)
+
+## Professional Open Source <a id="professional-open-source"></a>
+
+![Ortus Solutions, Corp](https://blobscdn.gitbook.com/v0/b/gitbook-28427.appspot.com/o/assets%2F-LA-UVvG0NM7NpDzssBL%2F-LA-Uaei0WzTH7Su5CR7%2F-LA-UqN1BRXynZ7RUVO7%2Fortussolutions_button.png?generation=1523647999385555&alt=media)
+
+The ColdBox ORM Module is a professional open source software backed by [Ortus Solutions, Corp](http://www.ortussolutions.com/services) offering services like:
+
+* Custom Development
+* Professional Support & Mentoring
+* Training
+* Server Tuning
+* Security Hardening
+* Code Reviews
+* [Much More](http://www.ortussolutions.com/services)
+
+### HONOR GOES TO GOD ABOVE ALL <a id="honor-goes-to-god-above-all"></a>
+
+Because of His grace, this project exists. If you don't like this, then don't read it, it's not for you.
+
+> "Therefore being justified by **faith**, we have peace with God through our Lord Jesus Christ: By whom also we have access by **faith** into this **grace** wherein we stand, and rejoice in hope of the glory of God." Romans 5:5

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -4,12 +4,7 @@
 2. [Configuration](configuration.md)
 3. [Supported Output Formats](#supported-formats)
 
-## SYSTEM REQUIREMENTS
-
-- Lucee 5+
-- ColdFusion 2016+
-
-## Supported Formats
+## Supported Output Formats
 
 DocBox supports several output formats:
 
@@ -17,4 +12,38 @@ DocBox supports several output formats:
 * [JSON](output-formats/json.md)
 * [UML](output-formats/uml.md)
 
-Each format can be configured by its alias name (such as `"JSON"` or `"HTML"`) or its full class path, such as `docbox.strategy.api.HTMLAPIStrategy`. This enables you to create your own documentation strategy and use it to produce documentation in a custom, proprietary format.
+Each format is configured by its alias name, such as `"JSON"` or `"HTML"`.
+
+```js
+var docbox = new docbox.DocBox();
+docbox.addStrategy( "UML", { outputFile : "./tmp/docs/app-diagram.uml" })
+```
+
+For backwards compatibility, specifying the full class path is still supported, as is specifying a single strategy when initializing DocBox:
+
+```js
+variables.docbox = new docbox.DocBox(
+  strategy = "docbox.strategy.uml2tools.XMIStrategy",
+  properties={ 
+    projectTitle = "DocBox Tests",
+    outputFile   = variables.testOutputFile
+  }
+);
+```
+
+### Custom Output Strategy
+
+In addition to the mainstream output formats, you can extend DocBox's `AbstractTemplateStrategy` component to generate your own custom-formatted documentation:
+
+```js
+component extends="docbox.strategy.AbstractTemplateStrategy" accessors="true"{
+   /**
+    * Generate JSON documentation
+    * 
+    * @metadata All component metadata, sourced from DocBox.
+    */
+   component function run( required query metadata ){
+      // generate custom documentation format from arguments.metadata
+   }
+}
+```

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -1,0 +1,20 @@
+## Getting Started
+
+1. [Installation](installation.md)
+2. [Configuration](configuration.md)
+3. [Supported Output Formats](#supported-formats)
+
+## SYSTEM REQUIREMENTS
+
+- Lucee 5+
+- ColdFusion 2016+
+
+## Supported Formats
+
+DocBox supports several output formats:
+
+* [HTML](output-formats/html.md)
+* [JSON](output-formats/json.md)
+* [UML](output-formats/uml.md)
+
+Each format can be configured by its alias name (such as `"JSON"` or `"HTML"`) or its full class path, such as `docbox.strategy.api.HTMLAPIStrategy`. This enables you to create your own documentation strategy and use it to produce documentation in a custom, proprietary format.

--- a/getting-started/configuration.md
+++ b/getting-started/configuration.md
@@ -1,0 +1,40 @@
+# Configuring DocBox
+
+1. Create a `generateDocs.cfm` CFML script file which will contain the docbox configuration
+2. Edit `generateDocs.cfm` and add CFML which will:
+   1. Create a new instance of `docbox.DocBox`
+   2. Choose an output format - `.addStrategy( "HTML" )`
+   3. Pass strategy parameters - `addStrategy( "HTML", { outputDir : 'tmp/docs' } )`
+   4. Run Docbox: `.generate()`
+
+```js
+new docbox.DocBox()
+    .addStrategy( "HTML", {
+        projectTitle : "CommandBox",
+        outputDir : "#expandPath( './docs' )#
+    } )
+    .generate(
+       source = expandPath( "/app" ),
+       mapping = "app",
+       excludes="(coldbox)"
+    );
+```
+
+You can generate multiple formats simultaneously with the `.addStrategy()` method:
+
+```js
+new docbox.DocBox()
+   .addStrategy( "HTML", {
+      projectTitle="My Docs",
+      outputDir="#expandPath( '/docs/html' )#"
+   } )
+   .addStrategy( "JSON", {
+      projectTitle="My Docs",
+      outputDir="#expandPath( '/docs/json' )#"
+   } )
+   .generate(
+      source = expandPath( "/app" ),
+      mapping = "app",
+      excludes="(coldbox)"
+   );
+```

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -1,0 +1,20 @@
+# Installation
+
+There are two main flavors of DocBox: Standalone and CLI.
+
+## Standalone
+
+To generate documentation from your CFML application:
+
+1. Run `box install docbox --saveDev` to install docbox to your application
+2. Create a `docbox` mapping that points to the DocBox source code location
+
+You will need to create a CFML script which runs DocBox against your source code. See [Getting Started](README.md) for more details.
+
+## CLI
+
+We also have a [CommandBox module](https://forgebox.io/view/commandbox-docbox) to enable generating documentation from the CLI. 
+
+1. Run `box install commandbox-docbox` to install the `docbox` command namespace
+2. Run `docbox help` to get a list of commands
+3. Run `docbox generate help` to show help for the `docbox generate` command

--- a/output-formats/json.md
+++ b/output-formats/json.md
@@ -1,0 +1,182 @@
+## JSON Output Format
+
+## Schema
+
+The JSON strategy outputs three types of files:
+
+- [JSON Output Format](#json-output-format)
+- [Schema](#schema)
+- [Overview Summary](#overview-summary)
+- [Package Summary](#package-summary)
+- [myClass.json](#myclassjson)
+
+## Overview Summary
+
+DocBox's JSON strategy outputs a single `overview-summary.json` file in the root of the configured `outputDir` directory that documents all packages (component directories) and classes in the configured `source`.
+
+```json
+{
+    "$id": "point-to-public-json-schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Package documentation index",
+    "description": "This class index links to each generated class documentation JSON file.",
+    "required": [],
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string"
+        },
+        "classes": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "path": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "packages": {
+            "type": "object",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "path": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+See an example at [JSONSchemaValidator.net](https://www.jsonschemavalidator.net/s/1GwKCCI3)
+
+## Package Summary
+
+DocBox's JSON strategy outputs a `package-summary.json` file for every directory found in the configured `source` directory that contains at least one ColdFusion component.
+
+* `source/autos/autoBuilder.cfc` will generate a `docs/source/autos/package-summary.json`
+
+```json
+{
+    "$id": "point-to-public-json-schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Package documentation index",
+    "description": "Index file documenting each coldfusion component inside a package level - i.e. per directory.",
+    "required": [],
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string"
+        },
+        "classes": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "path": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+See an example at [JSONSchemaValidator.net](https://www.jsonschemavalidator.net/s/98ToeO23)
+
+## myClass.json
+
+DocBox's JSON strategy outputs a single `class.json` file for every `.cfc` component found in the configured `source` directory.
+
+The name of the file will reflect the component name, and the location will match the source directory hierarchy:
+
+* `source/app/autos/autoBuilder.cfc` becomes `docs/source/app/autos/autoBuilder.json`
+* `source/main.cfc` becomes `docs/source/main.json`
+
+The component documentation will match this schema:
+
+```json
+{
+    "$id": "point-to-public-json-schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Class documentation",
+    "description": "Documents a single class in a ColdFusion package.",
+    "required": [],
+    "definitions": {
+        "function" : {
+            "type" : "object",
+            "properties": {
+                "name" : { "type" : "string" },
+                "hint" : { "type" : "string" },
+                "description" : { "type" : "string" },
+                "access" : { "type" : "string" },
+                "parameters" : {
+                    "type" : "array",
+                    "items": { "$ref" : "#/definitions/parameter" }
+                },
+                "returnType" : { "type" : "string" },
+                "returnFormat" : { "type" : "string" },
+                "position" : {
+                    "type" : "object",
+                    "properties" : {
+                        "start" : { "type" : "integer" },
+                        "end" : { "type" : "integer" }
+                    }
+                }
+            }
+        },
+        "parameter" : {
+            "type" : "object",
+            "properties": {
+                "type" : { "type" : "string" },
+                "name" : { "type" : "string" },
+                "required" : { "type" : "boolean" },
+                "default" : { "type" : "string" }
+            }
+        }
+    },
+    "type": "object",
+    "properties": {
+        "name" : { "type": "string" },
+        "package" : { "type": "string" },
+        "type" : { "type": "string" },
+        "extends" : { "type" : "string" },
+        "implements" : { "type" : "string" },
+        "hint" : { "type" : "string" },
+        "description" : { "type" : "string" },
+        "properties" : {
+            "description" : "Literally the component properties set via `property` or `cfproperty`.",
+            "type" : "object",
+            "properties": {
+                "type" : { "type" : "string" },
+                "name" : { "type" : "string" },
+                "access" : { "type" : "string" },
+                "hint" : { "type" : "string" },
+                "default" : { "type" : "string" },
+                "required" : { "type" : "boolean" }
+            }
+        },
+        "constructor" : { "$ref": "#/definitions/function" },
+        "functions" : {
+            "type" : "array",
+            "items" : { "$ref": "#/definitions/function" }
+        }
+    }
+  }
+```
+
+See an example at [JSONSchemaValidator.net](https://www.jsonschemavalidator.net/s/6Py2AIDk)


### PR DESCRIPTION
DocBox documentation, man!

- [x] Expanded "Installation" docs
- [x] Improved "Contribution" docs
- [x] Multi-strategy output documentation
- [x] Strategy aliases preferred in docs (because 90% of devs will copy/paste from the docs, right?)
- [x] Added "Custom Output Strategy" section
- [x] Added backwards compatibility note for passing strategy and properties via constructor 
- [x] Documents JSON output - links to schema in JSONSchemaValidator.net for extra credit 
- [x] Documents HTML output
- [x] Documents UML output